### PR TITLE
Fixed error when there are no modules.

### DIFF
--- a/internal/module/fetch.go
+++ b/internal/module/fetch.go
@@ -16,6 +16,10 @@ import (
 )
 
 func Fetch(ctx context.Context, refs []model.ModuleReference) ([]model.Module, error) {
+	if len(refs) == 0 {
+		return []model.Module{}, nil
+	}
+
 	goBin, err := exec.LookPath("go")
 	if err != nil {
 		return nil, err

--- a/internal/module/fetch_test.go
+++ b/internal/module/fetch_test.go
@@ -1,0 +1,17 @@
+package module_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uw-labs/lichen/internal/model"
+	"github.com/uw-labs/lichen/internal/module"
+)
+
+func TestModuleFetchNoModules(test *testing.T) {
+	modules, err := module.Fetch(context.Background(), []model.ModuleReference{})
+
+	assert.NoError(test, err)
+	assert.Empty(test, modules)
+}


### PR DESCRIPTION
Closes #1

Added unit test.

For simple go.mod file and main.go without modules lichen fails.
It returns status error code 1 which error message:

failed to evaluate licenses: failed to fetch: exit status 1 (output: go mod download: no modules specified (see 'go help mod download')
)

It should return status success code 0 without any error messages.