### PR TITLE
Log more helpful error when binary path does not exist

### DIFF
--- a/internal/module/extract.go
+++ b/internal/module/extract.go
@@ -63,7 +63,10 @@ func goVersion(ctx context.Context, paths []string) (string, error) {
 	cmd.Dir = tempDir
 	out, err := cmd.Output()
 	if err != nil {
-		return "", err
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("error when running 'go version': %w - stderr: %s", err, exitErr.Stderr)
+		}
+		return "", fmt.Errorf("error when running 'go version': %w", err)
 	}
 
 	return string(out), err


### PR DESCRIPTION
```text
$ /tmp/lichen foo
2021/01/26 18:40:02 failed to evaluate licenses: error when running 'go version': exit status 1 - stderr: stat /Users/abas/vmware/lichen/foo: no such file or directory
```

instead of:

```text
2021/01/26 18:40:02 failed to evaluate licenses: exit status 1
```