### PR TITLE
buildinfo parser: handle version strings from Go dev builds

### DIFF
--- a/internal/buildinfo/parse_test.go
+++ b/internal/buildinfo/parse_test.go
@@ -117,22 +117,43 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name:        "not executable file",
-			input:       `/tmp/lichen: not executable file`,
-			expectedErr: "/tmp/lichen is not an executable",
+			name:  "development version (pre-go1.17)",
+			input: `/tmp/lichen: devel +01821137c2 Sat Apr 3 01:45:17 2021 +0000`,
+			expected: []model.BuildInfo{
+				{
+					Path: "/tmp/lichen",
+				},
+			},
 		},
 		{
-			name:        "unrecognised exe file",
-			input:       `/tmp/lichen: unrecognized executable format`,
-			expectedErr: "/tmp/lichen has an unrecognized executable format",
+			name:  "development version (current)",
+			input: `/tmp/lichen: devel go1.18-0c83e01e0c Wed Aug 18 15:11:52 2021 +0000`,
+			expected: []model.BuildInfo{
+				{
+					Path: "/tmp/lichen",
+				},
+			},
 		},
 		{
-			name:        "go version not found",
-			input:       `/tmp/lichen: go version not found`,
-			expectedErr: "/tmp/lichen does not appear to be a Go compiled binary",
+			name:  "development version (old)",
+			input: `/tmp/lichen: devel +b7a85e0003 linux/amd64`,
+			expected: []model.BuildInfo{
+				{
+					Path: "/tmp/lichen",
+				},
+			},
 		},
 		{
-			name:        "invalid",
+			name:  "windows development version",
+			input: `C:\lichen.exe: devel go1.18-0c83e01e0c Wed Aug 18 15:11:52 2021 +0000`,
+			expected: []model.BuildInfo{
+				{
+					Path: `C:\lichen.exe`,
+				},
+			},
+		},
+		{
+			name:        "unrecognised line",
 			input:       `/tmp/lichen: invalid`,
 			expectedErr: "unrecognised version line: /tmp/lichen: invalid",
 		},

--- a/internal/module/extract.go
+++ b/internal/module/extract.go
@@ -24,7 +24,7 @@ func Extract(ctx context.Context, paths ...string) ([]model.BuildInfo, error) {
 		return nil, err
 	}
 	if err := verifyExtracted(parsed, paths); err != nil {
-		return nil, fmt.Errorf("could not extract module information from binaries: %v", paths)
+		return nil, fmt.Errorf("could not extract module information: %w", err)
 	}
 	return parsed, nil
 }
@@ -37,7 +37,7 @@ func verifyExtracted(extracted []model.BuildInfo, requested []string) (err error
 	}
 	for _, path := range requested {
 		if _, found := buildInfos[path]; !found {
-			err = multierror.Append(err, fmt.Errorf("modules could not be obtained from %s", path))
+			err = multierror.Append(err, fmt.Errorf("modules could not be obtained from %[1]s (hint: run `go version -m %[1]q`)", path))
 		}
 	}
 	return


### PR DESCRIPTION
With the [various possible version strings in play](https://github.com/uw-labs/lichen/issues/10#issuecomment-901810516), trying to parse
this line is a bit haphazard. We really only need to extract the
executable path, so I've switched to using a regex. That comes at
a cost of less semantic error returns, but as it happens we weren't
receiving these error lines anyway.. they are printed to stderr,
and we only capture stdout from `go version -m ...`. There is the
option to capture stderr as well, but in a way only dealing with
stdout makes life easier as there is less of a chance we mishandle
an error line, etc.

The `verifyExtracted` function already picks up on any paths not
parsed from the output - I've adjusted the error handling slightly so
it's more obvious what has caused the issue.

Resolves #10