### PR TITLE
Add vendoring support

### DIFF
--- a/internal/module/fetch.go
+++ b/internal/module/fetch.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/uw-labs/lichen/internal/model"
@@ -20,38 +21,75 @@ func Fetch(ctx context.Context, refs []model.ModuleReference) ([]model.Module, e
 		return []model.Module{}, nil
 	}
 
-	goBin, err := exec.LookPath("go")
-	if err != nil {
+	var (
+		f   fetcher
+		err error
+	)
+
+	if f.goBin, err = exec.LookPath("go"); err != nil {
 		return nil, err
 	}
 
-	tempDir, err := ioutil.TempDir("", "lichen")
-	if err != nil {
+	if f.tempDir, err = ioutil.TempDir("", "lichen"); err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)
 	}
-	defer os.Remove(tempDir)
+	defer os.Remove(f.tempDir)
 
-	hasVendor := false
-	if _, err := os.Stat("./vendor"); err == nil {
-		hasVendor = true
+	if strings.Contains(os.Getenv("GOFLAGS"), "-mod=vendor") {
+		f.vendorMode = true
+	} else if _, err := os.Stat("./vendor/modules.txt"); err == nil {
+		f.vendorMode = true
 	}
 
-	args := []string{"list", "-m", "-mod=readonly", "-json"}
+	args := []string{"mod", "download", "-json"}
+	if f.vendorMode {
+		args = []string{"list", "-m", "-json", "-mod=readonly"}
+	}
+
 	for _, ref := range refs {
 		if !ref.IsLocal() {
 			args = append(args, ref.String())
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, goBin, args...)
-	cmd.Dir = tempDir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch: %w (output: %s)", err, string(out))
+	if err = f.fetch(ctx, args); err != nil {
+		return nil, err
 	}
 
-	// parse JSON output from `go mod download`
-	modules := make([]model.Module, 0)
+	// add local modules, as these won't be included in the set returned by `go mod download`
+	for _, ref := range refs {
+		if ref.IsLocal() {
+			f.modules = append(f.modules, model.Module{
+				ModuleReference: ref,
+			})
+		}
+	}
+
+	// sanity check: all modules should have been covered in the output from `go mod download`
+	if err := f.verifyFetched(refs); err != nil {
+		return nil, fmt.Errorf("failed to fetch all modules: %w", err)
+	}
+
+	return f.modules, nil
+}
+
+type fetcher struct {
+	goBin      string
+	tempDir    string
+	vendorMode bool
+
+	modules []model.Module
+}
+
+func (f *fetcher) fetch(ctx context.Context, args []string) error {
+	cmd := exec.CommandContext(ctx, f.goBin, args...)
+	cmd.Dir = f.tempDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to fetch: %w (output: %s)", err, string(out))
+	}
+
+	// parse JSON output from `go mod list` or `go mod download`
 	dec := json.NewDecoder(bytes.NewReader(out))
 	for {
 		var m model.Module
@@ -59,38 +97,28 @@ func Fetch(ctx context.Context, refs []model.ModuleReference) ([]model.Module, e
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			return nil, err
+			return err
 		}
 
-		if hasVendor {
+		if f.vendorMode {
 			if _, err := os.Stat("./vendor/" + m.Path); err == nil {
 				m.Dir = "./vendor/" + m.Path
 			}
 		}
 
-		modules = append(modules, m)
-	}
-
-	// add local modules, as these won't be included in the set returned by `go mod download`
-	for _, ref := range refs {
-		if ref.IsLocal() {
-			modules = append(modules, model.Module{
-				ModuleReference: ref,
-			})
+		if m.Dir == "" {
+			continue
 		}
+
+		f.modules = append(f.modules, m)
 	}
 
-	// sanity check: all modules should have been covered in the output from `go mod download`
-	if err := verifyFetched(modules, refs); err != nil {
-		return nil, fmt.Errorf("failed to fetch all modules: %w", err)
-	}
-
-	return modules, nil
+	return nil
 }
 
-func verifyFetched(fetched []model.Module, requested []model.ModuleReference) (err error) {
-	fetchedRefs := make(map[model.ModuleReference]struct{}, len(fetched))
-	for _, module := range fetched {
+func (f *fetcher) verifyFetched(requested []model.ModuleReference) (err error) {
+	fetchedRefs := make(map[model.ModuleReference]struct{}, len(f.modules))
+	for _, module := range f.modules {
 		fetchedRefs[module.ModuleReference] = struct{}{}
 	}
 	for _, ref := range requested {

--- a/internal/module/fetch.go
+++ b/internal/module/fetch.go
@@ -31,7 +31,12 @@ func Fetch(ctx context.Context, refs []model.ModuleReference) ([]model.Module, e
 	}
 	defer os.Remove(tempDir)
 
-	args := []string{"mod", "download", "-json"}
+	hasVendor := false
+	if _, err := os.Stat("./vendor"); err == nil {
+		hasVendor = true
+	}
+
+	args := []string{"list", "-m", "-mod=readonly", "-json"}
 	for _, ref := range refs {
 		if !ref.IsLocal() {
 			args = append(args, ref.String())
@@ -56,6 +61,13 @@ func Fetch(ctx context.Context, refs []model.ModuleReference) ([]model.Module, e
 			}
 			return nil, err
 		}
+
+		if hasVendor {
+			if _, err := os.Stat("./vendor/" + m.Path); err == nil {
+				m.Dir = "./vendor/" + m.Path
+			}
+		}
+
 		modules = append(modules, m)
 	}
 


### PR DESCRIPTION
Resolves https://github.com/uw-labs/lichen/issues/8.

This PR adds best effort `vendor` support for cases when `lichen` is started from a module root which contains valid `vendor` directory with `modules.txt`. In case if modules cache is missing, which happens for some CI strategies, license is resolved from vendored module.

Can be tested with
```
go install github.com/vearutop/lichen@v0.1.6
```

Additional rationale for this feature: https://github.com/uw-labs/lichen/issues/8#issuecomment-916435625.

Looking forward for feedback. Thank you for such a convenient tool!