### PR TITLE
chore: improve error output

### DIFF
--- a/internal/module/fetch.go
+++ b/internal/module/fetch.go
@@ -54,7 +54,7 @@ func Fetch(ctx context.Context, refs []model.ModuleReference) ([]model.Module, e
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			return nil, err
+			return nil, fmt.Errorf("failed to decode JSON output: %w, value: %s", err, string(out))
 		}
 		modules = append(modules, m)
 	}


### PR DESCRIPTION
Changes returned error so that log would contain json value that failed to be parsed.

background: sometimes `go mod download` can print stuff that is not json (typically errors and/or warnings). Using combined output results in entire output (logs and all) to be parsed as json. This can result in an error and produce unclear output. This change suggests to make output more clear in this and possibly other cases.